### PR TITLE
Fix nonexisting property "error" in Generic.NamingConventions.ConstructorName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ in reverse chronological order by release.
 
 ## Unreleased
 
+### Fixed
+
+- Fix for nonexisting Generic.NamingConventions.ConstructorName property "error", use type instead.
+
 ## 1.2.4 - 2023-01-18
 
 ### Changed

--- a/Geniem/ruleset.xml
+++ b/Geniem/ruleset.xml
@@ -63,9 +63,7 @@
 
     <!-- We sometimes have used same class name and method name. -->
     <rule ref="Generic.NamingConventions.ConstructorName">
-        <properties>
-            <property name="error" value="false"/>
-        </properties>
+        <type>warning</type>
     </rule>
     <!-- Push to move away from deprecated functions, before they are removed. -->
     <rule ref="Generic.PHP.DeprecatedFunctions"/>


### PR DESCRIPTION
Fixes below error when running PHPCS commands.

```
ERROR: Ruleset invalid. Property "error" does not exist on sniff Generic.NamingConventions.ConstructorName
```